### PR TITLE
Persist Vuex state in localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5202,8 +5202,7 @@
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-      "dev": true
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -7444,6 +7443,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.orderby": {
       "version": "4.6.0",
@@ -11628,6 +11632,15 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.2.tgz",
       "integrity": "sha512-ha3jNLJqNhhrAemDXcmMJMKf1Zu4sybMPr9KxJIuOpVcsDQlTBYLLladav2U+g1AvdYDG5Gs0xBTb0M5pXXYFQ=="
+    },
+    "vuex-persist": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vuex-persist/-/vuex-persist-2.2.0.tgz",
+      "integrity": "sha512-o/qbBeMcKZZqMvCXc7kfIew/5cjHxlP1f53rx5YYp3r2tk2kxXYK/UZumxKn7OXywlurl2r0mgkuBzH6nIWFjw==",
+      "requires": {
+        "flatted": "^2.0.0",
+        "lodash.merge": "^4.6.2"
+      }
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vue": "^2.6.10",
     "vuetify": "^2.1.0",
     "vuex": "^3.1.2",
+    "vuex-persist": "^2.2.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
@@ -48,7 +49,12 @@
       "airbnb-base"
     ],
     "rules": {
-      "no-param-reassign": ["error", { "props": false }]
+      "no-param-reassign": [
+        "error",
+        {
+          "props": false
+        }
+      ]
     },
     "parserOptions": {
       "parser": "babel-eslint"

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,8 +33,9 @@ export default {
   ]),
 
   async created() {
-    this.$store.dispatch('getChannels');
-    this.$store.dispatch('getVideos');
+    this.$store.dispatch('getChannels').then(() => {
+      this.$store.dispatch('getVideos');
+    });
   },
 };
 </script>

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -13,7 +13,12 @@ export default {
   },
 
   async getChannels({ commit }) {
-    commit(types.GET_CHANNELS, await database.channels.toArray());
+    return new Promise((resolve) => {
+      database.channels.toArray().then((result) => {
+        commit(types.GET_CHANNELS, result);
+        resolve();
+      });
+    });
   },
 
   selectChannel({ commit, dispatch }, index) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import Vuex from 'vuex';
 import actions from './actions';
 import mutations from './mutations';
 import state from './state';
+import persistence from './persistence';
 
 Vue.use(Vuex);
 
@@ -11,4 +12,5 @@ export default new Vuex.Store({
   state,
   mutations,
   actions,
+  plugins: [persistence.plugin],
 });

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,0 +1,15 @@
+import VuexPersistence from 'vuex-persist';
+
+const ALLOWED_MUTATIONS = [
+  'TOGGLE_DRAWER',
+  'SELECT_CHANNEL',
+];
+
+export default new VuexPersistence({
+  storage: window.localStorage,
+  reducer: (state) => ({
+    drawer: state.drawer,
+    selectedChannel: state.selectedChannel,
+  }),
+  filter: (mutation) => ALLOWED_MUTATIONS.includes(mutation.type),
+});

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   transpileDependencies: [
     'vuetify',
+    'vuex-persist',
   ],
   pwa: {
     name: 'videoline',


### PR DESCRIPTION
Closes #12.

Includes and configures `vuex-persist`, and includes a small change in that the action `getChannels` is now promisified so that I can chain it in the main application `created` hook.

Before, both async actions would run into a race and now it's possible to have the videos of a selected channel pop up properly on a reload! 🎉 